### PR TITLE
优化 知识库删除和附件删除按钮的体验

### DIFF
--- a/apps/web-antd/src/api/system/knowledgeBase/index.ts
+++ b/apps/web-antd/src/api/system/knowledgeBase/index.ts
@@ -16,7 +16,7 @@ export function knowledgeList() {
 
 // 删除
 export function knowledgeDelete(id: any) {
-  return requestClient.post<any>(`${Api.knowledgeDelete}/${id}`);
+  return requestClient.deleteWithMsg<any>(`${Api.knowledgeDelete}/${id}`);
 }
 
 // 新增
@@ -31,7 +31,7 @@ export function knowledgeDetail(id: any) {
 
 // 附件删除
 export function knowledgeFileDelete(id: any) {
-  return requestClient.post<any>(`${Api.knowledgeFileDelete}/${id}`);
+  return requestClient.deleteWithMsg<any>(`${Api.knowledgeFileDelete}/${id}`);
 }
 
 // 知识片段列表

--- a/apps/web-antd/src/views/system/knowledgeBase/index.vue
+++ b/apps/web-antd/src/views/system/knowledgeBase/index.vue
@@ -149,11 +149,8 @@ const handleAdd = () => {
 
 // 删除
 const handleDelete = (record) => {
-  knowledgeDelete(record.kid).then((res) => {
-    if (res.code === 0) {
-      message.success('删除成功');
-      getList();
-    }
+  knowledgeDelete(record.id).then((res) => {
+    getList();
   });
 };
 
@@ -181,7 +178,6 @@ const fileColumns = [
 // 附件删除
 const handleDeleteFile = (record) => {
   knowledgeFileDelete(record.docId).then((res) => {
-    message.success('删除成功');
     getDetail(kid.value);
   });
 };


### PR DESCRIPTION
问题说明

知识库删除向后端传的kId，但是后端接收id。同时针对删除操作后端采用Post请求，不太符合Rustful API规范，我对后端的请求Mapper进行了简单修改以符合API规范，后端PR将会在后端仓库那边提出。