### PR TITLE
新增rerank模型

### DIFF
--- a/apps/web-antd/src/api/chat/model/index.ts
+++ b/apps/web-antd/src/api/chat/model/index.ts
@@ -17,6 +17,22 @@ export function modelList(params?: ModelQuery) {
 }
 
 /**
+ * 查询向量模型列表
+ * @returns 向量模型列表
+ */
+export function embeddingModelList() {
+  return modelList({ category: 'vector', pageSize: 1000 });
+}
+
+/**
+ * 查询重排序模型列表
+ * @returns 重排序模型列表
+ */
+export function rerankModelList() {
+  return modelList({ category: 'rerank', pageSize: 1000 });
+}
+
+/**
  * 导出模型管理列表
  * @param params
  * @returns 模型管理列表

--- a/apps/web-antd/src/api/knowledge/info/model.d.ts
+++ b/apps/web-antd/src/api/knowledge/info/model.d.ts
@@ -57,6 +57,26 @@ export interface InfoVO {
   embeddingModel: string;
 
   /**
+   * 是否启用重排序（0 否 1是）
+   */
+  enableRerank: number;
+
+  /**
+   * 重排序模型名称
+   */
+  rerankModel: string;
+
+  /**
+   * 重排序后返回数量
+   */
+  rerankTopN: number;
+
+  /**
+   * 重排序分数阈值（0-1）
+   */
+  rerankScoreThreshold: number;
+
+  /**
    * 备注
    */
   remark: string;
@@ -118,6 +138,26 @@ export interface InfoForm extends BaseEntity {
    * 向量模型
    */
   embeddingModel?: string;
+
+  /**
+   * 是否启用重排序（0 否 1是）
+   */
+  enableRerank?: number;
+
+  /**
+   * 重排序模型名称
+   */
+  rerankModel?: string;
+
+  /**
+   * 重排序后返回数量
+   */
+  rerankTopN?: number;
+
+  /**
+   * 重排序分数阈值（0-1）
+   */
+  rerankScoreThreshold?: number;
 
   /**
    * 备注

--- a/apps/web-antd/src/views/knowledge/info/info-drawer.vue
+++ b/apps/web-antd/src/views/knowledge/info/info-drawer.vue
@@ -2,7 +2,7 @@
 import type { RuleObject } from 'ant-design-vue/es/form';
 import type { InfoForm } from '#/api/knowledge/info/model';
 
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { $t } from '@vben/locales';
 import { cloneDeep } from '@vben/utils';
 
@@ -18,11 +18,13 @@ import {
   Button,
   Space,
   message,
+  Switch,
+  Slider,
 } from 'ant-design-vue';
 import { pick } from 'lodash-es';
 
 import { infoAdd, infoInfo, infoUpdate } from '#/api/knowledge/info';
-import { modelList } from '#/api/chat/model';
+import { embeddingModelList, rerankModelList } from '#/api/chat/model';
 
 const emit = defineEmits<{ reload: [] }>();
 
@@ -45,6 +47,10 @@ const defaultValues: Partial<InfoForm> = {
   textBlockSize: undefined,
   vectorModel: undefined,
   embeddingModel: undefined,
+  enableRerank: undefined,
+  rerankModel: undefined,
+  rerankTopN: undefined,
+  rerankScoreThreshold: undefined,
   remark: undefined,
 };
 
@@ -62,6 +68,9 @@ const formRules = ref<AntdFormRules<InfoForm>>({
   retrieveLimit: [{ required: true, message: '知识库检索条数不能为空' }],
   textBlockSize: [{ required: true, message: '文本块大小不能为空' }],
   overlapChar: [{ required: true, message: '重叠字符数不能为空' }],
+  rerankModel: [{ required: true, message: '请选择重排序模型' }],
+  rerankTopN: [{ required: true, message: '重排序返回数量不能为空' }],
+  rerankScoreThreshold: [{ required: true, message: '分数阈值不能为空' }],
 });
 
 const vectorModelOptions = [
@@ -70,6 +79,8 @@ const vectorModelOptions = [
 ];
 
 const embeddingModelOptions = ref<Array<{ label: string; value: string }>>([]);
+
+const rerankModelOptions = ref<Array<{ label: string; value: string }>>([]);
 
 const shareOptions = [
   { label: '是', value: 1 },
@@ -83,7 +94,7 @@ const { validate, validateInfos, resetFields } = Form.useForm(
 
 async function fetchEmbeddingModels() {
   try {
-    const response = await modelList({ category: 'vector', pageSize: 1000 });
+    const response = await embeddingModelList();
     const models = Array.isArray(response) ? response : (response.rows || response.records || []);
     embeddingModelOptions.value = models.map((model: any) => ({
       label: model.modelDescribe,
@@ -94,10 +105,46 @@ async function fetchEmbeddingModels() {
   }
 }
 
+async function fetchRerankModels() {
+  try {
+    const response = await rerankModelList();
+    const models = Array.isArray(response) ? response : (response.rows || response.records || []);
+    rerankModelOptions.value = models.map((model: any) => ({
+      label: model.modelDescribe,
+      value: model.modelName,
+    }));
+  } catch (error) {
+    console.error('Failed to fetch rerank models:', error);
+  }
+}
+
+// 监听检索条数变化，确保重排序返回数量不超过检索条数
+watch(() => formData.value.retrieveLimit, (newVal) => {
+  if (formData.value.rerankTopN && newVal && formData.value.rerankTopN > newVal) {
+    formData.value.rerankTopN = newVal;
+  }
+});
+
+// 监听启用重排序变化
+watch(() => formData.value.enableRerank, (newVal) => {
+  if (newVal === 1) {
+    // 启用重排序时，设置默认值
+    if (!formData.value.rerankModel && rerankModelOptions.value.length > 0) {
+      formData.value.rerankModel = rerankModelOptions.value[0].value;
+    }
+    if (!formData.value.rerankTopN) {
+      formData.value.rerankTopN = Math.min(5, formData.value.retrieveLimit || 5);
+    }
+    if (formData.value.rerankScoreThreshold === undefined) {
+      formData.value.rerankScoreThreshold = 0.5;
+    }
+  }
+});
+
 async function handleOpen(id?: string | number) {
   loading.value = true;
   try {
-    await fetchEmbeddingModels();
+    await Promise.all([fetchEmbeddingModels(), fetchRerankModels()]);
 
     isUpdate.value = !!id;
 
@@ -109,6 +156,9 @@ async function handleOpen(id?: string | number) {
       const defaultEmbeddingModel = embeddingModelOptions.value.length > 0
         ? embeddingModelOptions.value[0].value
         : undefined;
+      const defaultRerankModel = rerankModelOptions.value.length > 0
+        ? rerankModelOptions.value[0].value
+        : undefined;
 
       formData.value = {
         ...defaultValues,
@@ -118,6 +168,10 @@ async function handleOpen(id?: string | number) {
         retrieveLimit: 5,
         textBlockSize: 300,
         overlapChar: 30,
+        enableRerank: 0,
+        rerankModel: defaultRerankModel,
+        rerankTopN: 5,
+        rerankScoreThreshold: 0.5,
       };
     }
 
@@ -228,6 +282,47 @@ defineExpose({
           :placeholder="$t('ui.formRules.required')"
         />
       </FormItem>
+      <FormItem label="启用重排序">
+        <Switch
+          v-model:checked="formData.enableRerank"
+          :checked-value="1"
+          :un-checked-value="0"
+        />
+      </FormItem>
+      <template v-if="formData.enableRerank === 1">
+        <FormItem label="重排序模型" v-bind="validateInfos.rerankModel">
+          <Select
+            :key="`rerank-${rerankModelOptions.length}`"
+            v-model:value="formData.rerankModel"
+            :options="rerankModelOptions"
+            :placeholder="$t('ui.formRules.required')"
+          />
+        </FormItem>
+        <FormItem label="重排序数量" v-bind="validateInfos.rerankTopN">
+          <InputNumber
+            v-model:value="formData.rerankTopN"
+            style="width: 100%"
+            :placeholder="$t('ui.formRules.required')"
+            :min="1"
+            :max="formData.retrieveLimit || 100"
+          />
+          <div v-if="formData.retrieveLimit" class="text-gray-400 text-xs mt-1">
+            不能超过检索条数 ({{ formData.retrieveLimit }})
+          </div>
+        </FormItem>
+        <FormItem label="分数阈值" v-bind="validateInfos.rerankScoreThreshold">
+          <div class="flex items-center gap-3">
+            <Slider
+              v-model:value="formData.rerankScoreThreshold"
+              :min="0"
+              :max="1"
+              :step="0.01"
+              style="flex: 1"
+            />
+            <span class="w-12 text-right">{{ (formData.rerankScoreThreshold || 0).toFixed(2) }}</span>
+          </div>
+        </FormItem>
+      </template>
       <FormItem label="备注" v-bind="validateInfos.remark">
         <Input.TextArea
           v-model:value="formData.remark"

--- a/apps/web-antd/src/views/knowledge/info/info-modal.vue
+++ b/apps/web-antd/src/views/knowledge/info/info-modal.vue
@@ -8,7 +8,7 @@ import type { RuleObject } from 'ant-design-vue/es/form';
 
 import type { InfoForm } from '#/api/system/info/model';
 
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import { useVbenModal } from '@vben/common-ui';
 import { $t } from '@vben/locales';
@@ -24,11 +24,13 @@ import {
   Select,
   Radio,
   RadioGroup,
+  Switch,
+  Slider,
 } from 'ant-design-vue';
 import { pick } from 'lodash-es';
 
 import { infoAdd, infoInfo, infoUpdate } from '#/api/knowledge/info';
-import { modelList } from '#/api/chat/model';
+import { embeddingModelList, rerankModelList } from '#/api/chat/model';
 
 const accessStore = useAccessStore();
 
@@ -53,6 +55,10 @@ const defaultValues: Partial<InfoForm> = {
   textBlockSize: undefined,
   vectorModel: undefined,
   embeddingModel: undefined,
+  enableRerank: undefined,
+  rerankModel: undefined,
+  rerankTopN: undefined,
+  rerankScoreThreshold: undefined,
   remark: undefined,
 };
 
@@ -75,6 +81,9 @@ const formRules = ref<AntdFormRules<InfoForm>>({
   retrieveLimit: [{ required: true, message: '知识库检索条数不能为空' }],
   textBlockSize: [{ required: true, message: '文本块大小不能为空' }],
   overlapChar: [{ required: true, message: '重叠字符数不能为空' }],
+  rerankModel: [{ required: true, message: '请选择重排序模型' }],
+  rerankTopN: [{ required: true, message: '重排序返回数量不能为空' }],
+  rerankScoreThreshold: [{ required: true, message: '分数阈值不能为空' }],
 });
 
 const vectorModelOptions = [
@@ -83,6 +92,8 @@ const vectorModelOptions = [
 ];
 
 const embeddingModelOptions = ref<Array<{ label: string; value: string }>>([]);
+
+const rerankModelOptions = ref<Array<{ label: string; value: string }>>([]);
 
 const shareOptions = [
   { label: '是', value: 1 },
@@ -99,8 +110,7 @@ const { validate, validateInfos, resetFields } = Form.useForm(
 
 async function fetchEmbeddingModels() {
   try {
-    const response = await modelList({ category: 'vector', pageSize: 1000 });
-    // 处理响应格式：rows 或 records
+    const response = await embeddingModelList();
     const models = Array.isArray(response) ? response : (response.rows || response.records || []);
     embeddingModelOptions.value = models.map((model: any) => ({
       label: model.modelDescribe,
@@ -110,6 +120,42 @@ async function fetchEmbeddingModels() {
     console.error('Failed to fetch embedding models:', error);
   }
 }
+
+async function fetchRerankModels() {
+  try {
+    const response = await rerankModelList();
+    const models = Array.isArray(response) ? response : (response.rows || response.records || []);
+    rerankModelOptions.value = models.map((model: any) => ({
+      label: model.modelDescribe,
+      value: model.modelName,
+    }));
+  } catch (error) {
+    console.error('Failed to fetch rerank models:', error);
+  }
+}
+
+// 监听检索条数变化，确保重排序返回数量不超过检索条数
+watch(() => formData.value.retrieveLimit, (newVal) => {
+  if (formData.value.rerankTopN && newVal && formData.value.rerankTopN > newVal) {
+    formData.value.rerankTopN = newVal;
+  }
+});
+
+// 监听启用重排序变化
+watch(() => formData.value.enableRerank, (newVal) => {
+  if (newVal === 1) {
+    // 启用重排序时，设置默认值
+    if (!formData.value.rerankModel && rerankModelOptions.value.length > 0) {
+      formData.value.rerankModel = rerankModelOptions.value[0].value;
+    }
+    if (!formData.value.rerankTopN) {
+      formData.value.rerankTopN = Math.min(5, formData.value.retrieveLimit || 5);
+    }
+    if (formData.value.rerankScoreThreshold === undefined) {
+      formData.value.rerankScoreThreshold = 0.5;
+    }
+  }
+});
 
 const [BasicModal, modalApi] = useVbenModal({
   class: 'w-[550px]',
@@ -123,7 +169,7 @@ const [BasicModal, modalApi] = useVbenModal({
     }
     modalApi.modalLoading(true);
 
-    await fetchEmbeddingModels();
+    await Promise.all([fetchEmbeddingModels(), fetchRerankModels()]);
 
     const { id } = modalApi.getData() as { id?: number | string };
     isUpdate.value = !!id;
@@ -138,6 +184,9 @@ const [BasicModal, modalApi] = useVbenModal({
       const defaultEmbeddingModel = embeddingModelOptions.value.length > 0
         ? embeddingModelOptions.value[0].value
         : undefined;
+      const defaultRerankModel = rerankModelOptions.value.length > 0
+        ? rerankModelOptions.value[0].value
+        : undefined;
 
       formData.value = {
         ...defaultValues,
@@ -147,6 +196,10 @@ const [BasicModal, modalApi] = useVbenModal({
         retrieveLimit: 5,
         textBlockSize: 300,
         overlapChar: 30,
+        enableRerank: 0,
+        rerankModel: defaultRerankModel,
+        rerankTopN: 5,
+        rerankScoreThreshold: 0.5,
       };
     }
 
@@ -245,6 +298,47 @@ async function handleCancel() {
           :placeholder="$t('ui.formRules.required')"
         />
       </FormItem>
+      <FormItem label="启用重排序">
+        <Switch
+          v-model:checked="formData.enableRerank"
+          :checked-value="1"
+          :un-checked-value="0"
+        />
+      </FormItem>
+      <template v-if="formData.enableRerank === 1">
+        <FormItem label="重排序模型" v-bind="validateInfos.rerankModel">
+          <Select
+            :key="`rerank-${rerankModelOptions.length}`"
+            v-model:value="formData.rerankModel"
+            :options="rerankModelOptions"
+            :placeholder="$t('ui.formRules.required')"
+          />
+        </FormItem>
+        <FormItem label="重排序数量" v-bind="validateInfos.rerankTopN">
+          <InputNumber
+            v-model:value="formData.rerankTopN"
+            style="width: 100%"
+            :placeholder="$t('ui.formRules.required')"
+            :min="1"
+            :max="formData.retrieveLimit || 100"
+          />
+          <div v-if="formData.retrieveLimit" class="text-gray-400 text-xs mt-1">
+            不能超过检索条数 ({{ formData.retrieveLimit }})
+          </div>
+        </FormItem>
+        <FormItem label="分数阈值" v-bind="validateInfos.rerankScoreThreshold">
+          <div class="flex items-center gap-3">
+            <Slider
+              v-model:value="formData.rerankScoreThreshold"
+              :min="0"
+              :max="1"
+              :step="0.01"
+              style="flex: 1"
+            />
+            <span class="w-12 text-right">{{ (formData.rerankScoreThreshold || 0).toFixed(2) }}</span>
+          </div>
+        </FormItem>
+      </template>
       <FormItem label="备注" v-bind="validateInfos.remark">
         <Textarea
           v-model:value="formData.remark"


### PR DESCRIPTION
## 功能说明
知识库重排序功能**前端界面开发**，支持配置重排序相关参数。

## 实现内容
1. 在知识库配置页新增**重排序配置区域**
2. 支持配置：
   - 是否启用重排序
   - 重排序模型选择
   - 相关性分数阈值
   - 重排序返回文档数量
3. 界面样式、表单校验与现有系统统一
4. 与后端适配