### PR TITLE
解决前端所有时间显示时间戳问题

### DIFF
--- a/apps/web-antd/src/api/request.ts
+++ b/apps/web-antd/src/api/request.ts
@@ -23,6 +23,7 @@ import {
   AesEncryption,
   decodeBase64,
   encodeBase64,
+  formatDateTime,
   randomStr,
   RsaEncryption,
 } from '@vben/utils';
@@ -37,12 +38,16 @@ import { handleUnauthorizedLogout } from './helper';
 const { apiURL, clientId, enableEncrypt, rsaPublicKey, rsaPrivateKey } =
   useAppConfig(import.meta.env, import.meta.env.PROD);
 
+const DATE_TIME_FIELD_PATTERN = /(?:Time|Date|At|_time|_date|_at)$/;
+const NON_DATE_TIME_FIELDS = new Set(['costTime']);
+const TIMESTAMP_PATTERN = /^\d{10}(\d{3})?$/;
+
 /**
  * 使用非对称加密的实现 前端已经实现RSA/SM2
  *
  * 你可以使用Sm2Encryption来替换 后端也需要同步替换公私钥对
  *
- * 后端文件位置: ruoyi-common/ruoyi-common-encrypt/src/main/java/org/dromara/common/encrypt/filter/DecryptRequestBodyWrapper.java
+ * 后端文件位置: meet-common/meet-common-encrypt/src/main/java/org/dromara/common/encrypt/filter/DecryptRequestBodyWrapper.java
  *
  * 注意前端sm-crypto库只能支持04开头的公钥! 否则加密会有问题 你可以使用前端的import { logSm2KeyPair } from '@vben/utils';方法来生成
  * 如果你生成的公钥开头不是04 那么不能正常加密
@@ -124,7 +129,7 @@ function createRequestClient(baseURL: string) {
       /**
        * 添加全局clientId
        * 关于header的clientId被错误绑定到实体类
-       * https://gitee.com/dapppp/ruoyi-plus-vben5/issues/IC0BDS
+       * https://gitee.com/dapppp/meet-plus-vben5/issues/IC0BDS
        */
       config.headers.ClientID = clientId;
       /**
@@ -235,6 +240,7 @@ function createRequestClient(baseURL: string) {
             // 然后按正常逻辑执行下面的代码(判断业务状态码)
           } else {
             // 其他类型数据 直接返回
+            normalizeResponseDateTimes(response.data);
             return response.data;
           }
         } else {
@@ -244,6 +250,7 @@ function createRequestClient(baseURL: string) {
       }
 
       const axiosResponseData = response.data;
+      normalizeResponseDateTimes(axiosResponseData);
       if (!axiosResponseData) {
         throw new Error($t('http.apiRequestFailed'));
       }
@@ -322,6 +329,48 @@ function createRequestClient(baseURL: string) {
   );
 
   return client;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function normalizeResponseDateTimes(value: unknown) {
+  if (Array.isArray(value)) {
+    value.forEach(normalizeResponseDateTimes);
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    return;
+  }
+
+  Object.entries(value).forEach(([key, item]) => {
+    if (Array.isArray(item) || isPlainObject(item)) {
+      normalizeResponseDateTimes(item);
+      return;
+    }
+
+    if (shouldNormalizeDateTimeValue(key, item)) {
+      value[key] = formatDateTime(item as number | string);
+    }
+  });
+}
+
+function shouldNormalizeDateTimeValue(key: string, value: unknown) {
+  if (!DATE_TIME_FIELD_PATTERN.test(key) || NON_DATE_TIME_FIELDS.has(key)) {
+    return false;
+  }
+
+  if (typeof value === 'number') {
+    return value > 0 && value >= 1_000_000_000 && value < 10_000_000_000_000;
+  }
+
+  if (typeof value === 'string') {
+    return TIMESTAMP_PATTERN.test(value.trim());
+  }
+
+  return false;
 }
 
 export const requestClient = createRequestClient(apiURL);

--- a/packages/@core/base/shared/src/utils/date.ts
+++ b/packages/@core/base/shared/src/utils/date.ts
@@ -1,19 +1,50 @@
 import dayjs from 'dayjs';
 
-export function formatDate(time: number | string, format = 'YYYY-MM-DD') {
-  try {
-    const date = dayjs(time);
-    if (!date.isValid()) {
-      throw new Error('Invalid date');
+type DateInput = Date | number | string;
+
+function normalizeDateInput(time: DateInput) {
+  if (typeof time === 'string') {
+    const trimmedTime = time.trim();
+
+    if (/^\d{10}$/.test(trimmedTime)) {
+      return Number(trimmedTime) * 1000;
     }
-    return date.format(format);
-  } catch (error) {
-    console.error(`Error formatting date: ${error}`);
+
+    if (/^\d{13}$/.test(trimmedTime)) {
+      return Number(trimmedTime);
+    }
+  }
+
+  if (typeof time !== 'number') {
     return time;
   }
+
+  return time > 0 && time < 10_000_000_000 ? time * 1000 : time;
 }
 
-export function formatDateTime(time: number | string) {
+export function formatDate(
+  time: DateInput | null | undefined,
+  format = 'YYYY-MM-DD',
+): number | string {
+  if (time === null || time === undefined || time === '') {
+    return '-';
+  }
+
+  if (typeof time === 'string' && /^\d{1,2}:\d{2}(:\d{2})?$/.test(time)) {
+    return time;
+  }
+
+  const date = dayjs(normalizeDateInput(time));
+  if (date.isValid()) {
+    return date.format(format);
+  }
+
+  return typeof time === 'number' ? time : String(time);
+}
+
+export function formatDateTime(
+  time: DateInput | null | undefined,
+): number | string {
   return formatDate(time, 'YYYY-MM-DD HH:mm:ss');
 }
 

--- a/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
+++ b/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
@@ -32,6 +32,7 @@ import { usePreferences } from '@vben/preferences';
 import {
   cloneDeep,
   cn,
+  formatDateTime,
   isBoolean,
   isEqual,
   mergeWithArrayOverride,
@@ -60,6 +61,9 @@ const FORM_SLOT_PREFIX = 'form-';
 const TOOLBAR_ACTIONS = 'toolbar-actions';
 const TOOLBAR_TOOLS = 'toolbar-tools';
 const TABLE_TITLE = 'table-title';
+
+const DATE_TIME_FIELD_PATTERN = /(?:Time|Date|At|_time|_date|_at)$/;
+const DURATION_FIELD_NAMES = new Set(['costTime']);
 
 const gridRef = useTemplateRef<VxeGridInstance>('gridRef');
 
@@ -93,8 +97,8 @@ const isSeparator = computed(() => {
 });
 const separatorBg = computed(() => {
   return !separator.value ||
-    isBoolean(separator.value) ||
-    !separator.value.backgroundColor
+  isBoolean(separator.value) ||
+  !separator.value.backgroundColor
     ? undefined
     : separator.value.backgroundColor;
 });
@@ -193,6 +197,8 @@ const options = computed(() => {
     ),
   );
 
+  applyDefaultDateTimeFormatters(mergedOptions.columns);
+
   if (mergedOptions.proxyConfig) {
     const { ajax } = mergedOptions.proxyConfig;
     mergedOptions.proxyConfig.enabled = !!ajax;
@@ -233,6 +239,38 @@ const options = computed(() => {
   }
   return mergedOptions;
 });
+
+function applyDefaultDateTimeFormatters(columns: VxeTableGridProps['columns']) {
+  columns?.forEach((column) => {
+    if (column.children) {
+      applyDefaultDateTimeFormatters(column.children);
+    }
+
+    if (!shouldUseDefaultDateTimeFormatter(column)) {
+      return;
+    }
+
+    column.formatter = ({ cellValue }) => formatDateTime(cellValue);
+  });
+}
+
+function shouldUseDefaultDateTimeFormatter(
+  column: NonNullable<VxeTableGridProps['columns']>[number],
+) {
+  const field = column.field;
+  if (
+    !field ||
+    DURATION_FIELD_NAMES.has(field) ||
+    column.cellRender ||
+    column.editRender ||
+    column.formatter ||
+    column.slots?.default
+  ) {
+    return false;
+  }
+
+  return DATE_TIME_FIELD_PATTERN.test(field);
+}
 
 function onToolbarToolClick(event: VxeGridDefines.ToolbarToolClickEventParams) {
   if (event.code === 'search') {


### PR DESCRIPTION
遇到createTime/updateTime/*Date/*At等字段仍是10/13位时间戳时，统一转正常时间。VXE 表格入口自动给时间列加默认formatter，已有自定义渲染不会覆盖，增强date.ts，兼容 10 位秒级时间戳、字符串时间戳、空值、纯 HH:mm 时间。